### PR TITLE
Allow null props for Grapher

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -5,6 +5,7 @@ import _ from 'lodash'
 
 import GraphUtil from './helpers/graph-util.js'
 import type {GraphSettingsT, PointT, GraphTypeT, GraphPropertiesT} from './helpers/graph-util.js'
+import {fromMaybe, fromMaybeNonEmpty} from './helpers/maybe-helper.js'
 
 const defaultMinGridX = -10
 const defaultMaxGridX = 10
@@ -21,31 +22,15 @@ const defaultPointColors =
   , '#643173'
   ]
 
-type GrapherProps =
-  { onPointChanged: (movingPoint: ?PointT, graphProperties: GraphPropertiesT) => void
-  , graphType: GraphTypeT
-  , minGridX?: number
-  , maxGridX?: number
-  , minGridY?: number
-  , maxGridY?: number
-  , stepX?: number
-  , stepY?: number
-  , pointSize?: number
-  , pointColors?: Array<string>
-  }
-
 const getGraphSetting = function(grapherProps: GrapherProps): GraphSettingsT {
-  const minGridX = grapherProps.minGridX ? grapherProps.minGridX: defaultMinGridX
-  const maxGridX = grapherProps.maxGridX ? grapherProps.maxGridX : defaultMaxGridX
-  const minGridY = grapherProps.minGridY ? grapherProps.minGridY : defaultMinGridY
-  const maxGridY = grapherProps.maxGridY ? grapherProps.maxGridY : defaultMaxGridY
-  const stepX = grapherProps.stepX ? grapherProps.stepX : defaultStepX
-  const stepY = grapherProps.stepY ? grapherProps.stepY : defaultStepY
-  const pointSize = grapherProps.pointSize ? grapherProps.pointSize : defaultPointSize
-  const pointColors =
-    grapherProps.pointColors && !_.isEmpty(grapherProps.pointColors) ?
-      grapherProps.pointColors :
-      defaultPointColors
+  const minGridX = fromMaybe(defaultMinGridX, grapherProps.minGridX)
+  const maxGridX = fromMaybe(defaultMaxGridX, grapherProps.maxGridX)
+  const minGridY = fromMaybe(defaultMinGridY, grapherProps.minGridY)
+  const maxGridY = fromMaybe(defaultMaxGridY, grapherProps.maxGridY)
+  const stepX = fromMaybe(defaultStepX, grapherProps.stepX)
+  const stepY = fromMaybe(defaultStepY, grapherProps.stepY)
+  const pointSize = fromMaybe(defaultPointSize, grapherProps.pointSize)
+  const pointColors = fromMaybeNonEmpty(defaultPointColors, grapherProps.pointColors)
 
   const baseGraphSettings =
     { minGridX
@@ -105,6 +90,19 @@ const getGraphSetting = function(grapherProps: GrapherProps): GraphSettingsT {
       throw new Error (`Could not recognize graph type: ${grapherProps.graphType}`)
   }
 }
+
+type GrapherProps =
+  { onPointChanged: (movingPoint: ?PointT, graphProperties: GraphPropertiesT) => void
+  , graphType: GraphTypeT
+  , minGridX?: ?number
+  , maxGridX?: ?number
+  , minGridY?: ?number
+  , maxGridY?: ?number
+  , stepX?: ?number
+  , stepY?: ?number
+  , pointSize?: ?number
+  , pointColors?: ?Array<string>
+  }
 
 export default class Grapher extends React.Component<void, GrapherProps, void> {
   static defaultProps: void;

--- a/src/helpers/maybe-helper.js
+++ b/src/helpers/maybe-helper.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+export function fromMaybe<T>(defaultValue: T, t: ?T): T {
+  return t === null || t === undefined ? defaultValue : t
+}
+
+export function fromMaybeNonEmpty<T>(defaultValue: Array<T>, t: ?Array<T>): Array<T> {
+  return t === null || t === undefined || t.length === 0 ? defaultValue : t
+}


### PR DESCRIPTION
This will accept non existing to be also null: 

```
<Grapher
  minGridX={null}
  ...
/>
```

This is the same as omitting the `minGridX` props.
There is already a fallback for null/undefined/non-existing props.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/2)

<!-- Reviewable:end -->
