### PR TITLE
Pass normalized (whole-step) points to onPointChanged() callback

### DIFF
--- a/src/helpers/graph/graph-exponential-util.js
+++ b/src/helpers/graph/graph-exponential-util.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import _ from 'lodash'
+
 import {getClosestStepPoint} from './../graph-util.js'
 import {getArrayOfNElements} from './../array-helper.js'
 import type {GraphSettingsT, PointT, GraphPropertiesT} from './../graph-util.js'
@@ -16,11 +18,12 @@ const GraphExponentialUtil = {
 
     const moveAndUpdate = function(movedPoint: PointT, points: Array<PointT>) {
       const stepPoint = getClosestStepPoint(movedPoint, graphSettings)
+      const stepPoints: Array<PointT> = _.map(points, point => getClosestStepPoint(point, graphSettings))
       const hasMoved = graph.exponentialEquation.moveDraggedItemAt(stepPoint)
       if (hasMoved) {
         const graphProperties =
           { graphType: 'exponential'
-          , property: { points }
+          , property: { points: stepPoints }
           }
         onPointChanged(stepPoint, graphProperties)
         graph.exponentialEquation.updateFunction()

--- a/src/helpers/graph/graph-linear-inequality-util.js
+++ b/src/helpers/graph/graph-linear-inequality-util.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import _ from 'lodash'
+
 import {getClosestStepPoint} from './../graph-util.js'
 import {getArrayOfNElements} from './../array-helper.js'
 import type {GraphSettingsT, PointT, GraphPropertiesT, InequalityT} from './../graph-util.js'
@@ -17,14 +19,15 @@ const GraphLinearInequalityUtil = {
     graph.linearEquationInequality.setInequality(graphSettings.inequality)
     graph.linearEquationInequality.updateFunction()
 
-    const moveAndUpdate = function(movedPoint: PointT, points: Array<PointT>, inequality: InequalityT) {
+    const moveAndUpdate = function(movedPoint: PointT, points: Array<PointT>, inequality: InequalityT, setInequality: bool) {
       const stepPoint = getClosestStepPoint(movedPoint, graphSettings)
+      const stepPoints: Array<PointT> = _.map(points, point => getClosestStepPoint(point, graphSettings))
       const hasMoved = graph.linearEquationInequality.moveDraggedItemAt(stepPoint)
-      if (hasMoved) {
+      if (hasMoved || setInequality) {
         const graphProperties =
           { graphType: 'linear-inequality'
           , property:
-            { points
+            { points: stepPoints
             , inequality
             }
           }
@@ -35,15 +38,15 @@ const GraphLinearInequalityUtil = {
 
     const onMouseDown = function(movedPoint: PointT, points: Array<PointT>, inequality: InequalityT) {
       graph.linearEquationInequality.startDraggingItemAt(movedPoint)
-      moveAndUpdate(movedPoint, points, inequality)
+      moveAndUpdate(movedPoint, points, inequality, true)
     }
 
     const onMouseMove = function(movedPoint: PointT, points: Array<PointT>, inequality: InequalityT) {
-      moveAndUpdate(movedPoint, points, inequality)
+      moveAndUpdate(movedPoint, points, inequality, false)
     }
 
     const onMouseUp = function(movedPoint: PointT, points: Array<PointT>, inequality: InequalityT) {
-      moveAndUpdate(movedPoint, points, inequality)
+      moveAndUpdate(movedPoint, points, inequality, true)
       graph.linearEquationInequality.stopDraggingItem()
     }
 

--- a/src/helpers/graph/graph-linear-util.js
+++ b/src/helpers/graph/graph-linear-util.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import _ from 'lodash'
+
 import {getClosestStepPoint} from './../graph-util.js'
 import {getArrayOfNElements} from './../array-helper.js'
 import type {GraphSettingsT, PointT, GraphPropertiesT} from './../graph-util.js'
@@ -16,11 +18,12 @@ const GraphLinearUtil = {
 
     const moveAndUpdate = function(movedPoint: PointT, points: Array<PointT>) {
       const stepPoint = getClosestStepPoint(movedPoint, graphSettings)
+      const stepPoints: Array<PointT> = _.map(points, point => getClosestStepPoint(point, graphSettings))
       const hasMoved = graph.linearEquation.moveDraggedItemAt(stepPoint)
       if (hasMoved) {
         const graphProperties =
           { graphType: 'linear'
-          , property: { points }
+          , property: { points: stepPoints }
           }
         onPointChanged(stepPoint, graphProperties)
         graph.linearEquation.updateFunction()

--- a/src/helpers/graph/graph-quadratic-util.js
+++ b/src/helpers/graph/graph-quadratic-util.js
@@ -21,8 +21,8 @@ const GraphQuadraticUtil = {
         const graphProperties =
           { graphType: 'quadratic'
           , property:
-            { vertex
-            , point
+            { vertex: getClosestStepPoint(vertex, graphSettings)
+            , point: getClosestStepPoint(point, graphSettings)
             }
           }
         onPointChanged(stepPoint, graphProperties)

--- a/src/helpers/graph/graph-scatter-points-util.js
+++ b/src/helpers/graph/graph-scatter-points-util.js
@@ -16,11 +16,12 @@ const GraphScatterPointsUtil = {
 
     const moveAndUpdate = function(movedPoint: PointT, points: Array<PointT>) {
       const stepPoint = getClosestStepPoint(movedPoint, graphSettings)
+      const stepPoints: Array<PointT> = _.map(points, point => getClosestStepPoint(point, graphSettings))
       const hasMoved = graph.scatterPoints.moveDraggedItemAt(stepPoint)
       if (hasMoved) {
         const graphProperties =
           { graphType: 'scatter-points'
-          , property: { points }
+          , property: { points: stepPoints }
           }
 
         onPointChanged(stepPoint, graphProperties)


### PR DESCRIPTION
We want most computation to deal with non-normalized points because we get better precision, but the callback wants normalized points for doing things like checking correctness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/13)
<!-- Reviewable:end -->
