### PR TITLE
Use Math.round to calculate whole-step points

### DIFF
--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -72,8 +72,8 @@ export type GraphPropertiesT =
 export function getClosestStepPoint(point: PointT, graphSettings: GraphSettingsT): PointT {
   const {stepX, stepY} = graphSettings
   return (
-    { x: Math.ceil(point.x/stepX) * stepX
-    , y: Math.ceil(point.y/stepY) * stepY
+    { x: Math.round(point.x/stepX) * stepX
+    , y: Math.round(point.y/stepY) * stepY
     }
   )
 }


### PR DESCRIPTION
`Math.ceil` truncates negative numbers towards zero, e.g. 3.9 gets truncated to 3 instead of rounded to 4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/14)
<!-- Reviewable:end -->
