### PR TITLE
Reinitialize canvas when props change

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -119,12 +119,15 @@ export default class Grapher extends React.Component<void, GrapherProps, void> {
     this.reset(this.props)
   }
 
+  // We should only update if the props have changed
   shouldComponentUpdate(nextProps: GrapherProps): boolean {
     const graphSettings = getGraphSetting(this.props)
     const nextGraphSettings = getGraphSetting(nextProps)
     return !_.isEqual(graphSettings, nextGraphSettings)
   }
 
+  // Updating means running setupGraph again to destroy what's currently
+  // on the canvas and re-draw
   componentWillUpdate(nextProps: GrapherProps) {
     this.reset(nextProps)
   }

--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -133,6 +133,10 @@ const GraphUtil = {
       default:
         throw new Error (`Could not recognize graph type: ${this.props.graphType}`)
     }
+  },
+
+  destroy: function() {
+    PaperUtil.destroy()
   }
 }
 export default GraphUtil

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -134,9 +134,9 @@ type GroupKeyT
   | 'inequality-side'
 
 const PaperUtil = {
-
   setupGraph: function(canvas: any, graphSettings: GraphSettingsT): any {
     const initialize = (): any => {
+      this.destroy()
       paper.setup(canvas)
 
       // Move View to be centered on 0,0 of the Grid which is determined by
@@ -462,6 +462,12 @@ const PaperUtil = {
     }
 
     return initialize(canvas)
+  },
+
+  destroy: function() {
+    if (paper.project) {
+      paper.project.clear()
+    }
   }
 }
 


### PR DESCRIPTION
Previously, changes to props were not being recognized since we were only initializing the canvas with our initial props and then ignoring new props.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/16)
<!-- Reviewable:end -->
