### PR TITLE
Fix issue where event handlers weren't getting removed

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -114,9 +114,24 @@ export default class Grapher extends React.Component<void, GrapherProps, void> {
   static defaultProps: void;
   props: GrapherProps;
   state: void;
+  graph: any;
 
   componentDidMount() {
     this.reset(this.props)
+  }
+
+  componentWillUnmount() {
+    if (this.graph) {
+      this.graph.destroy()
+      this.graph = null
+    }
+  }
+
+  // We should only update if the props have changed
+  componentWillReceiveProps(nextProps: GrapherProps) {
+    if (this.shouldComponentUpdate(nextProps)) {
+      this.componentWillUpdate(nextProps)
+    }
   }
 
   // We should only update if the props have changed
@@ -135,13 +150,11 @@ export default class Grapher extends React.Component<void, GrapherProps, void> {
   reset(props: GrapherProps) {
     const canvas = document.getElementById(`graph-${props.graphType}-canvas`)
     const graphSettings = getGraphSetting(props)
-    GraphUtil.setupGraph(props.graphType, canvas, props.onPointChanged, graphSettings)
+    if (this.graph) {
+      this.graph.destroy()
+    }
+    this.graph = GraphUtil.setupGraph(props.graphType, canvas, props.onPointChanged, graphSettings)
   }
-
-  componentDidUnmount() {
-    GraphUtil.destroy()
-  }
-
   render() {
     return (
       <canvas

--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -52,7 +52,9 @@ export type ExponentialGraphPropertyT =
   { points: Array<PointT> }
 
 export type LinearInequalityGraphPropertyT =
-  { points: Array<PointT> } & InequalityT
+  { points: Array<PointT>
+  , inequality: InequalityT
+  }
 
 export type ScatterPointsGraphPropertyT =
   { points: Array<PointT> }
@@ -109,7 +111,7 @@ const GraphUtil = {
 
   // This function initialize the canvas with the drawing library,
   // set the grid on the canvas and set the default points for the graph
-  setupGraph: function(graphType: GraphTypeT, canvas: any, onPointChanged: (movingPoint: ?PointT, graphProperties: GraphPropertiesT) => void, graphSettings: GraphSettingsT) {
+  setupGraph: function(graphType: GraphTypeT, canvas: any, onPointChanged: (movingPoint: ?PointT, graphProperties: GraphPropertiesT) => void, graphSettings: GraphSettingsT): any {
     const graph = PaperUtil.setupGraph(canvas, graphSettings)
 
     GraphUtil.createGrid(graph, graphSettings)
@@ -133,10 +135,7 @@ const GraphUtil = {
       default:
         throw new Error (`Could not recognize graph type: ${this.props.graphType}`)
     }
+    return graph
   },
-
-  destroy: function() {
-    PaperUtil.destroy()
-  }
 }
 export default GraphUtil

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -145,11 +145,12 @@ const PaperUtil = {
       // Because Y axis is inverted (coef -1) to have negative number, the
       // translation has to be based on View Height
       const {minGridX, maxGridX, minGridY, maxGridY} = graphSettings
-      const widthGrid = Math.abs(maxGridX) + Math.abs(minGridX)
-      const heightGrid = Math.abs(maxGridY) + Math.abs(minGridY)
-      const tx = paper.view.size.width * (Math.abs(minGridX) / widthGrid)
-      const ty = paper.view.size.height - (paper.view.size.height * (Math.abs(minGridY) / heightGrid))
-      paper.view.transform(new paper.Matrix(1,0,0,-1,tx, ty))
+      const widthGrid = Math.abs(maxGridX - minGridX)
+      const heightGrid = Math.abs(maxGridY - minGridY)
+
+      const tx = minGridX * (paper.view.size.width / widthGrid)
+      const ty = minGridY * (paper.view.size.height / heightGrid) + paper.view.size.height
+      paper.view.transform(new paper.Matrix(1, 0, 0, -1, -tx, ty))
 
       this.groups = {}
       this.groups['grid'] = new paper.Group()

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -136,7 +136,6 @@ type GroupKeyT
 const PaperUtil = {
   setupGraph: function(canvas: any, graphSettings: GraphSettingsT): any {
     const initialize = (): any => {
-      this.destroy()
       paper.setup(canvas)
 
       // Move View to be centered on 0,0 of the Grid which is determined by
@@ -154,14 +153,56 @@ const PaperUtil = {
 
       this.groups = {}
       this.groups['grid'] = new paper.Group()
-      this.groups['points'] = new paper.Group()
+      const pointsGroup = this.groups['points'] = new paper.Group()
       this.groups['curve'] = new paper.Group()
       this.groups['vertex'] = new paper.Group()
       this.groups['point'] = new paper.Group()
       this.groups['inequality-side'] = new paper.Group()
+      this.pointsTool = new paper.Tool(pointsGroup)
+      this.pointsTool.activate()
 
       paper.view.draw()
       return this
+    }
+
+    this.destroy = () => {
+      if (this.groups) {
+        this.groups = {}
+      }
+
+      this.removeHandlers()
+      if (this.pointsTool) {
+        this.pointsTool.remove()
+        this.pointsTool = null
+      }
+
+      if (paper.project) {
+        paper.project.clear()
+      }
+    }
+
+    this.removeHandlers = () => {
+      if (this.pointsTool) {
+        if (this.onMouseDown) {
+          this.pointsTool.off('mousedown', this.onMouseDown)
+          this.onMouseDown = null
+        }
+        if (this.onMouseDrag) {
+          this.pointsTool.off('mousedrag', this.onMouseDrag)
+          this.onMouseDrag = null
+        }
+        if (this.onMouseUp) {
+          this.pointsTool.off('mouseup', this.onMouseUp)
+          this.onMouseUp = null
+        }
+      }
+    }
+
+    this.setDraggable = (onMouseDown, onMouseDrag, onMouseUp) => {
+      this.removeHandlers()
+      this.pointsTool.on('mousedown', this.onMouseDown = onMouseDown)
+      this.pointsTool.on('mousedrag', this.onMouseDrag = onMouseDrag)
+      this.pointsTool.on('mouseup', this.onMouseUp = onMouseUp)
     }
 
     // Make the conversion from Grid coordinates to view coordinates
@@ -226,10 +267,17 @@ const PaperUtil = {
       },
 
       setDraggable: (onMouseDown, onMouseDrag, onMouseUp) => {
-        const pointsTool = new paper.Tool(this.groups['points'])
-        pointsTool.onMouseDown = event => { this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points')) }
-        pointsTool.onMouseDrag = event => { this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points')) }
-        pointsTool.onMouseUp = event => { this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points')) }
+        this.setDraggable(
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points'))
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points'))
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points'))
+          }
+        )
       },
 
       startDraggingItemAt: (point: PointT) => {
@@ -272,10 +320,17 @@ const PaperUtil = {
       },
 
       setDraggable: (onMouseDown, onMouseDrag, onMouseUp) => {
-        const pointsTool = new paper.Tool()
-        pointsTool.onMouseDown = event => { this.callFuncWithConvertedPoint(onMouseDown, event.point, this.quadraticEquation.getVertexAndPoint()) }
-        pointsTool.onMouseDrag = event => { this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.quadraticEquation.getVertexAndPoint()) }
-        pointsTool.onMouseUp = event => { this.callFuncWithConvertedPoint(onMouseUp, event.point, this.quadraticEquation.getVertexAndPoint()) }
+        this.setDraggable(
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDown, event.point, this.quadraticEquation.getVertexAndPoint())
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.quadraticEquation.getVertexAndPoint())
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseUp, event.point, this.quadraticEquation.getVertexAndPoint())
+          }
+        )
       },
 
       startDraggingItemAt: (point: PointT) => {
@@ -310,10 +365,17 @@ const PaperUtil = {
       },
 
       setDraggable: (onMouseDown, onMouseDrag, onMouseUp) => {
-        const pointsTool = new paper.Tool()
-        pointsTool.onMouseDown = event => { this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points')) }
-        pointsTool.onMouseDrag = event => { this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points')) }
-        pointsTool.onMouseUp = event => { this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points')) }
+        this.setDraggable(
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points'))
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points'))
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points'))
+          }
+        )
       },
 
       startDraggingItemAt: (point: PointT) => {
@@ -348,10 +410,17 @@ const PaperUtil = {
     this.scatterPoints = {
 
       setDraggable: (onMouseDown, onMouseDrag, onMouseUp) => {
-        const pointsTool = new paper.Tool()
-        pointsTool.onMouseDown = event => { this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points')) }
-        pointsTool.onMouseDrag = event => { this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points')) }
-        pointsTool.onMouseUp = event => { this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points')) }
+        this.setDraggable(
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points'))
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points'))
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points'))
+          }
+        )
       },
 
       startDraggingItemAt: (point: PointT) => {
@@ -416,10 +485,17 @@ const PaperUtil = {
       },
 
       setDraggable: (onMouseDown, onMouseDrag, onMouseUp) => {
-        const pointsTool = new paper.Tool(this.groups['points'])
-        pointsTool.onMouseDown = event => { this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points'), this.linearEquationInequality.inequality) }
-        pointsTool.onMouseDrag = event => { this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points'), this.linearEquationInequality.inequality) }
-        pointsTool.onMouseUp = event => { this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points'), this.linearEquationInequality.inequality) }
+        this.setDraggable(
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDown, event.point, this.getAllPointsInGroup('points'), this.linearEquationInequality.inequality)
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseDrag, event.point, this.getAllPointsInGroup('points'), this.linearEquationInequality.inequality)
+          },
+          event => {
+            this.callFuncWithConvertedPoint(onMouseUp, event.point, this.getAllPointsInGroup('points'), this.linearEquationInequality.inequality)
+          }
+        )
       },
 
       startDraggingItemAt: (point: PointT) => {
@@ -462,12 +538,6 @@ const PaperUtil = {
     }
 
     return initialize(canvas)
-  },
-
-  destroy: function() {
-    if (paper.project) {
-      paper.project.clear()
-    }
   }
 }
 

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -166,14 +166,15 @@ const PaperUtil = {
     }
 
     this.destroy = () => {
-      if (this.groups) {
-        this.groups = {}
-      }
-
       this.removeHandlers()
+
       if (this.pointsTool) {
         this.pointsTool.remove()
         this.pointsTool = null
+      }
+
+      if (this.groups) {
+        this.groups = {}
       }
 
       if (paper.project) {


### PR DESCRIPTION
When we navigated back to a graphy component, the original event handlers would still be attached, and we would call `setState` on an unmounted component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/17)
<!-- Reviewable:end -->
