### PR TITLE
Subdivide the grid steps when generating curves for more precision

### DIFF
--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -231,10 +231,14 @@ const PaperUtil = {
     }
 
     this.traceCurve = (group: GroupKeyT, fn: ((x: number) => number), minXGridPoint: number, maxXGridPoint: number, stepGridX: number, color: string, isDashed: boolean = false) => {
-      const gridRangePoints = _.range(minXGridPoint, maxXGridPoint + stepGridX, stepGridX)
-      const paperPoints = _.map(gridRangePoints, x => this.fromGridCoordinateToView({x, y: fn(x)}))
-      const path = new paper.Path(paperPoints)
-      path.smooth('continuous')
+      // Subdivide the grid steps for more precision
+      const xs = _.range(minXGridPoint, maxXGridPoint + stepGridX, stepGridX / 8.0)
+      const points = _.map(xs, x => this.fromGridCoordinateToView({x, y: fn(x)}))
+      const path = new paper.Path(points)
+
+      // Reduce the number of segments by fitting Bezier curves to the path
+      path.simplify()
+
       path.strokeColor = color
       path.dashArray = isDashed ? [10, 5] : []
       this.groups[group].addChild(path)


### PR DESCRIPTION
Also use `Path.simplify()` instead of `Path.smooth()`.

Before:
![before-exp](https://cloud.githubusercontent.com/assets/592078/23881184/10c60a04-0816-11e7-8bd8-bc7537a64928.png)

After:
![after-exp](https://cloud.githubusercontent.com/assets/592078/23881188/14422320-0816-11e7-90dd-afde5d8dec60.png)

The actual fix was just not enough precision, but the simplification is nice because we end up drawing (usually) less than 10 curves instad of a tens of line segments that get smoothed into (still) tens of line segments.

Linear and quadratic curves look the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/18)
<!-- Reviewable:end -->
