### PR TITLE
Use React ref instead of id for canvas

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -115,6 +115,7 @@ export default class Grapher extends React.Component<void, GrapherProps, void> {
   props: GrapherProps;
   state: void;
   graph: any;
+  canvas: HTMLElement;
 
   componentDidMount() {
     this.reset(this.props)
@@ -148,17 +149,16 @@ export default class Grapher extends React.Component<void, GrapherProps, void> {
   }
 
   reset(props: GrapherProps) {
-    const canvas = document.getElementById(`graph-${props.graphType}-canvas`)
-    const graphSettings = getGraphSetting(props)
     if (this.graph) {
       this.graph.destroy()
     }
-    this.graph = GraphUtil.setupGraph(props.graphType, canvas, props.onPointChanged, graphSettings)
+    this.graph = GraphUtil.setupGraph(props.graphType, this.canvas, props.onPointChanged, getGraphSetting(props))
   }
+
   render() {
     return (
       <canvas
-        id={`graph-${this.props.graphType}-canvas`}
+        ref={element => this.canvas = element}
         className="graph-canvas"
       >
       </canvas>


### PR DESCRIPTION
I'm not sure why we had different ids for the different graph types, but it was causing strange things to happen when we changed from one type to the next. Now we just use a ref. Since we re-set the paper project, I don't think there's any harm in using the same canvas for differen types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/19)
<!-- Reviewable:end -->
