### PR TITLE
Save initial canvas state on graph.initialize() and restore on destroy()

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -61,7 +61,7 @@ const getGraphSetting = function(grapherProps: GrapherProps): GraphSettingsT {
         ]
       break
     default:
-      throw new Error (`Could not recognize graph type: ${grapherProps.graphType}`)
+      throw new Error(`Could not recognize graph type: ${grapherProps.graphType}`)
   }
 
   const minGridX = fromMaybe(defaultMinGridX, grapherProps.minGridX)

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -136,6 +136,11 @@ type GroupKeyT
 const PaperUtil = {
   setupGraph: function(canvas: any, graphSettings: GraphSettingsT): any {
     const initialize = (): any => {
+      // Save initial canvas state (restore in destroy())
+      // We do this because on some version of Chrome for Mac OS X, paper.js seems
+      // to leave the canvas in a transformed state after clearing the project
+      canvas.getContext('2d').save()
+
       paper.setup(canvas)
 
       // Move View to be centered on 0,0 of the Grid which is determined by
@@ -181,6 +186,9 @@ const PaperUtil = {
       if (paper.project) {
         paper.project.clear()
       }
+
+      // Restore initial canvas state (save in initialize())
+      canvas.getContext('2d').restore()
     }
 
     this.removeHandlers = () => {


### PR DESCRIPTION
Paper.js doesn't seem to be un-doing the transforms it applies to the canvas, so now I'm doing it myself. This just runs `canvas.getContext('2d').save()` before calling `paper.setup(canvas)` and `canvas.getContext('2d').restore()` at the end of `graph.destroy()`.

The other option (which feels a little more like a sledgehammer) is to do `canvas.getContext('2d').setTransform(1, 0, 0, 1, 0, 0)` before calling `paper.setup(canvas)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphy/20)
<!-- Reviewable:end -->
