### PR TITLE
Add graphing bounds labels

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -70,6 +70,7 @@ const getGraphSetting = function(grapherProps: GrapherProps): GraphSettingsT {
   const maxGridY = fromMaybe(defaultMaxGridY, grapherProps.maxGridY)
   const stepX = fromMaybe(defaultStepX, grapherProps.stepX)
   const stepY = fromMaybe(defaultStepY, grapherProps.stepY)
+  const showBoundingLabels = fromMaybe(false, grapherProps.showBoundingLabels)
   const pointSize = fromMaybe(defaultPointSize, grapherProps.pointSize)
   const pointColors = fromMaybeNonEmpty(defaultPointColors, grapherProps.pointColors)
   const startingPoints =
@@ -92,6 +93,7 @@ const getGraphSetting = function(grapherProps: GrapherProps): GraphSettingsT {
     , pointColors
     , inequality
     , startingPoints
+    , showBoundingLabels
     }
   )
 }
@@ -108,6 +110,7 @@ type GrapherProps =
   , pointSize?: ?number
   , pointColors?: ?Array<string>
   , startingPoints?: Array<PointT>
+  , showBoundingLabels?: ?boolean
   }
 
 export default class Grapher extends React.Component<void, GrapherProps, void> {

--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -38,6 +38,7 @@ export type GraphSettingsT =
   , pointColors: Array<string>
   , pointSize: number
   , inequality?: InequalityT
+  , showBoundingLabels: ?boolean
   }
 
 export type LinearGraphPropertyT =
@@ -84,7 +85,7 @@ const GraphUtil = {
 
   // This function traces the grid on the canvas based on the graph settings
   createGrid: function(graph: any, graphSettings: GraphSettingsT) {
-    const {minGridX, maxGridX, minGridY, maxGridY, stepX, stepY} = graphSettings
+    const {minGridX, maxGridX, minGridY, maxGridY, stepX, stepY, showBoundingLabels} = graphSettings
     const minXAxisGrid = {x: minGridX, y: 0}
     const maxXAxisGrid = {x: maxGridX, y: 0}
     const minYAxisGrid = {x: 0, y: minGridY}
@@ -107,6 +108,20 @@ const GraphUtil = {
 
     graph.createLine('grid', minXAxisGrid, maxXAxisGrid, 'black')
     graph.createLine('grid', minYAxisGrid, maxYAxisGrid, 'black')
+
+    if(showBoundingLabels) {
+      graph.createLabel('label', minXAxisGrid, minGridX.toString(), 'left')
+      graph.createTick('tick', minXAxisGrid, 'x')
+
+      graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), 'right')
+      graph.createTick('tick', maxXAxisGrid, 'x')
+
+      graph.createLabel('label', minYAxisGrid, minGridY.toString(), 'bottom')
+      graph.createTick('tick', minYAxisGrid, 'y')
+
+      graph.createLabel('label', maxYAxisGrid, maxGridY.toString(), 'left')
+      graph.createTick('tick', maxYAxisGrid, 'y')
+    }
   },
 
   // This function initialize the canvas with the drawing library,


### PR DESCRIPTION
When `showBoundingLabels` is true, the graph will render like this:

<img width="791" alt="Screen Shot 2020-01-29 at 11 49 45" src="https://user-images.githubusercontent.com/201288/73382648-86f13c80-428d-11ea-82a9-d72b8aa94b28.png">
