### PR TITLE
fix: x-axis labels getting cut off

### DIFF
--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -128,11 +128,16 @@ const GraphUtil = {
     graph.createLine("grid", minYAxisGrid, maxYAxisGrid, "black");
 
     if (showBoundingLabels) {
-      graph.createLabel("label", minXAxisGrid, minGridX.toString(), "left");
-      graph.createTick("tick", minXAxisGrid, "x");
-
-      graph.createLabel("label", maxXAxisGrid, maxGridX.toString(), "right");
-      graph.createTick("tick", maxXAxisGrid, "x");
+      
+      if(minGridY > -4) {
+        graph.createLabel('label', minXAxisGrid, minGridX.toString(), 'bottom left');
+        graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), 'bottom right');
+      } else {
+        graph.createLabel('label', minXAxisGrid, minGridX.toString(), 'left');
+        graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), 'right');
+      }
+      graph.createTick('tick', maxXAxisGrid, 'x');
+      graph.createTick('tick', minXAxisGrid, 'x');
 
       graph.createLabel("label", minYAxisGrid, minGridY.toString(), "bottom");
       graph.createTick("tick", minYAxisGrid, "y");

--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -131,19 +131,19 @@ const GraphUtil = {
       
       // arrived at -4 through trial and error, observing the point where the cutoff from the bottom started
       if(minGridY > -4) {
-        graph.createLabel('label', minXAxisGrid, minGridX.toString(), 'bottom left');
-        graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), 'bottom right');
+        graph.createLabel('label', minXAxisGrid, minGridX.toString(), ['bottom', 'left']);
+        graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), ['bottom', 'right']);
       } else {
-        graph.createLabel('label', minXAxisGrid, minGridX.toString(), 'left');
-        graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), 'right');
+        graph.createLabel('label', minXAxisGrid, minGridX.toString(), ['left']);
+        graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), ['right']);
       }
       graph.createTick('tick', maxXAxisGrid, 'x');
       graph.createTick('tick', minXAxisGrid, 'x');
 
-      graph.createLabel("label", minYAxisGrid, minGridY.toString(), "bottom");
+      graph.createLabel("label", minYAxisGrid, minGridY.toString(), ["bottom"]);
       graph.createTick("tick", minYAxisGrid, "y");
 
-      graph.createLabel("label", maxYAxisGrid, maxGridY.toString(), "left");
+      graph.createLabel("label", maxYAxisGrid, maxGridY.toString(), ["left"]);
       graph.createTick("tick", maxYAxisGrid, "y");
     }
   },

--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -129,6 +129,7 @@ const GraphUtil = {
 
     if (showBoundingLabels) {
       
+      // arrived at -4 through trial and error, observing the point where the cutoff from the bottom started
       if(minGridY > -4) {
         graph.createLabel('label', minXAxisGrid, minGridX.toString(), 'bottom left');
         graph.createLabel('label', maxXAxisGrid, maxGridX.toString(), 'bottom right');

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -16,6 +16,7 @@ export type AnchorT
   = 'left'
   | 'bottom'
   | 'right'
+  | 'top'
 
 import
   { isPointBelowFunction
@@ -294,18 +295,18 @@ const PaperUtil = {
       this.groups[group].addChild(circle)
     }
 
-    this.createLabel = (group: GroupKeyT, axisBoundsGridCoordinatePoint: PointT, text: string, anchor: AnchorT = 'left') => {
+    this.createLabel = (group: GroupKeyT, axisBoundsGridCoordinatePoint: PointT, text: string, anchors: AnchorT[] = ['top', 'left']) => {
       const axisBoundsPoint = this.fromGridCoordinateToView(axisBoundsGridCoordinatePoint)
 
       let nextClosestVerticalPoint = null
-      if (anchor === 'bottom') {
+      if (anchors.indexOf('bottom') > -1) {
         nextClosestVerticalPoint = this.fromGridCoordinateToView({ x: axisBoundsGridCoordinatePoint.x, y: axisBoundsGridCoordinatePoint.y + 1 })
       } else {
         nextClosestVerticalPoint = this.fromGridCoordinateToView({ x: axisBoundsGridCoordinatePoint.x, y: axisBoundsGridCoordinatePoint.y - 1 })
       }
 
       let nextClosestHorizontalPoint = null
-      if (anchor === 'right') {
+      if (anchors.indexOf('right') > -1) {
         nextClosestHorizontalPoint = this.fromGridCoordinateToView({ x: axisBoundsGridCoordinatePoint.x - 1, y: axisBoundsGridCoordinatePoint.y })
       } else {
         nextClosestHorizontalPoint = this.fromGridCoordinateToView({ x: axisBoundsGridCoordinatePoint.x + 1, y: axisBoundsGridCoordinatePoint.y })
@@ -314,7 +315,7 @@ const PaperUtil = {
       const verticalOffset = (nextClosestVerticalPoint.y - axisBoundsPoint.y) / 10
       const horizontalOffset = (nextClosestHorizontalPoint.x - axisBoundsPoint.x) / 10
       const labelPoint = { x: axisBoundsPoint.x + horizontalOffset, y: axisBoundsPoint.y + verticalOffset }
-      const label = createLabel(labelPoint, text, anchor)
+      const label = createLabel(labelPoint, text, anchors[0])
 
       this.groups[group].addChild(label)
     }


### PR DESCRIPTION
Fix x-axis labels getting cut off from the bottom when the minimum y-axis value is greater than -4  by expanding existing label anchoring machinery to allow anchoring to more than 1 point.   ie.  anchors = ['bottom', 'left']

References https://app.asana.com/0/56224185180675/1200293536396017/f
