### PR TITLE
Move lodash to peer-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "webpack": "^3.0.0"
   },
   "dependencies": {
-    "lodash": "4.17.4",
     "paper": "0.11.4"
   },
   "peerDependencies": {
+    "lodash": "^4.17.4",
     "react": "16.2.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2804,14 +2804,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash@4.17.4, lodash@^4.2.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz"
-
 lodash@^4.15.0, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.2.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Task
https://app.asana.com/0/1200107221560708/1200107221560723/f
Student app: Assess packages we include in bundle and reduce size

## Description
Moving `lodash` to the `peerDependencies` to avoid duplicating `lodash` in the `megarepo/frontend` bundles.