### PR TITLE
Add codeowners from student team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @freckle/student-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @freckle/student-engineers
+* @freckle/team-student


### PR DESCRIPTION
The student team owns this library. They should be pulled in for review.