### PR TITLE
Enable keyboard support

### DIFF
--- a/src/grapher.js
+++ b/src/grapher.js
@@ -8,10 +8,10 @@ import GraphUtil from "./helpers/graph-util.js";
 import type {
   GraphSettingsT,
   PointT,
-  GraphTypeT,
   GraphPropertiesT,
   InequalityT,
 } from "./helpers/graph-util.js";
+import {type GraphTypeT} from './helpers/paper-util'
 import { fromMaybe, fromMaybeNonEmpty } from "./helpers/maybe-helper.js";
 
 const defaultMinGridX = -10;

--- a/src/grapher.js
+++ b/src/grapher.js
@@ -11,7 +11,7 @@ import type {
   GraphPropertiesT,
   InequalityT,
 } from "./helpers/graph-util.js";
-import {type GraphTypeT} from './helpers/paper-util'
+import {type GraphTypeT, ANNOUNCEMENT_NODE_ID} from './helpers/paper-util'
 import { fromMaybe, fromMaybeNonEmpty } from "./helpers/maybe-helper.js";
 
 const defaultMinGridX = -10;
@@ -196,9 +196,10 @@ export default class Grapher extends React.Component<void, GrapherProps, void> {
       <canvas
         ref={(element) => (this.canvas = element)}
         className="graph-canvas"
+        width="400" height="400"
         {...ariaDescribedbyAttr}
       >
-        {" "}
+        <div id={ANNOUNCEMENT_NODE_ID} aria-live="assertive"></div>
       </canvas>
     );
   }

--- a/src/helpers/graph-util.js
+++ b/src/helpers/graph-util.js
@@ -7,15 +7,7 @@ import GraphLinearInequalityUtil from "./graph/graph-linear-inequality-util.js";
 import GraphLinearUtil from "./graph/graph-linear-util.js";
 import GraphQuadraticUtil from "./graph/graph-quadratic-util.js";
 import GraphScatterPointsUtil from "./graph/graph-scatter-points-util.js";
-import PaperUtil from "./paper-util.js";
-
-export type GraphTypeT =
-  | "linear"
-  | "linear-inequality"
-  | "quadratic"
-  | "exponential"
-  | "scatter-points"
-  | "empty";
+import PaperUtil, {type GraphTypeT} from "./paper-util.js";
 
 export type InequalityT = "lt" | "le" | "gt" | "ge";
 
@@ -168,7 +160,7 @@ const GraphUtil = {
     ) => void,
     graphSettings: GraphSettingsT
   ): any {
-    const graph = PaperUtil.setupGraph(canvas, graphSettings);
+    const graph = PaperUtil.setupGraph(canvas, graphSettings, graphType);
 
     GraphUtil.createGrid(graph, graphSettings);
 

--- a/src/helpers/graph/graph-exponential-util.js
+++ b/src/helpers/graph/graph-exponential-util.js
@@ -38,7 +38,7 @@ const GraphExponentialUtil = {
     };
 
     const onMouseDown = function (point: PointT, points: Array<PointT>) {
-      graph.exponentialEquation.startDraggingItemAt(point);
+      graph.exponentialEquation.startDraggingItemAt(point, false);
       moveAndUpdate(point, points);
     };
     const onMouseMove = function (point: PointT, points: Array<PointT>) {
@@ -48,12 +48,17 @@ const GraphExponentialUtil = {
       moveAndUpdate(point, points);
       graph.exponentialEquation.stopDraggingItem();
     };
+    const onKeyDown = function(point: PointT, points: Array<PointT>) {
+      graph.exponentialEquation.startDraggingItemAt(point, true);
+      moveAndUpdate(point, points);
+    }
 
     if (graphSettings.canInteract)
       graph.exponentialEquation.setDraggable(
         onMouseDown,
         onMouseMove,
-        onMouseUp
+        onMouseUp,
+        onKeyDown
       );
   },
 };

--- a/src/helpers/graph/graph-exponential-util.js
+++ b/src/helpers/graph/graph-exponential-util.js
@@ -2,7 +2,6 @@
 
 import _ from "lodash";
 
-import { getArrayOfNElements } from "./../array-helper.js";
 import { getClosestStepPoint } from "./../graph-util.js";
 
 import type {
@@ -20,23 +19,6 @@ const GraphExponentialUtil = {
     ) => void,
     graphSettings: GraphSettingsT
   ) {
-    const [point1Color, point2Color] = getArrayOfNElements(
-      graphSettings.pointColors,
-      2
-    );
-    graph.createCircle(
-      "points",
-      graphSettings.startingPoints[0],
-      graphSettings.pointSize,
-      point1Color
-    );
-    graph.createCircle(
-      "points",
-      graphSettings.startingPoints[1],
-      graphSettings.pointSize,
-      point2Color
-    );
-
     graph.exponentialEquation.updateFunction();
 
     const moveAndUpdate = function (movedPoint: PointT, points: Array<PointT>) {

--- a/src/helpers/graph/graph-linear-inequality-util.js
+++ b/src/helpers/graph/graph-linear-inequality-util.js
@@ -2,7 +2,6 @@
 
 import _ from "lodash";
 
-import { getArrayOfNElements } from "./../array-helper.js";
 import { getClosestStepPoint } from "./../graph-util.js";
 
 import type {
@@ -21,22 +20,6 @@ const GraphLinearInequalityUtil = {
     ) => void,
     graphSettings: GraphSettingsT
   ) {
-    const [point1Color, point2Color] = getArrayOfNElements(
-      graphSettings.pointColors,
-      2
-    );
-    graph.createCircle(
-      "points",
-      graphSettings.startingPoints[0],
-      graphSettings.pointSize,
-      point1Color
-    );
-    graph.createCircle(
-      "points",
-      graphSettings.startingPoints[1],
-      graphSettings.pointSize,
-      point2Color
-    );
     if (!graphSettings.inequality) {
       throw new Error(
         "GraphLinearInequalityUtil.createGraph: graphSettings doesn't contain inequality property"

--- a/src/helpers/graph/graph-linear-inequality-util.js
+++ b/src/helpers/graph/graph-linear-inequality-util.js
@@ -56,7 +56,7 @@ const GraphLinearInequalityUtil = {
       points: Array<PointT>,
       inequality: InequalityT
     ) {
-      graph.linearEquationInequality.startDraggingItemAt(movedPoint);
+      graph.linearEquationInequality.startDraggingItemAt(movedPoint, false);
       moveAndUpdate(movedPoint, points, inequality, true);
     };
 
@@ -77,11 +77,21 @@ const GraphLinearInequalityUtil = {
       graph.linearEquationInequality.stopDraggingItem();
     };
 
+    const onKeyDown = function(
+      point: PointT, 
+      points: Array<PointT>, 
+      inequality: InequalityT
+    ) {
+      graph.linearEquationInequality.startDraggingItemAt(point, true);
+      moveAndUpdate(point, points, inequality, true);
+    }
+
     if (graphSettings.canInteract)
       graph.linearEquationInequality.setDraggable(
         onMouseDown,
         onMouseMove,
-        onMouseUp
+        onMouseUp,
+        onKeyDown
       );
   },
 };

--- a/src/helpers/graph/graph-linear-util.js
+++ b/src/helpers/graph/graph-linear-util.js
@@ -2,7 +2,6 @@
 
 import _ from "lodash";
 
-import { getArrayOfNElements } from "./../array-helper.js";
 import { getClosestStepPoint } from "./../graph-util.js";
 
 import type {
@@ -20,23 +19,6 @@ const GraphLinearUtil = {
     ) => void,
     graphSettings: GraphSettingsT
   ) {
-    const [point1Color, point2Color] = getArrayOfNElements(
-      graphSettings.pointColors,
-      2
-    );
-    graph.createCircle(
-      "points",
-      graphSettings.startingPoints[0],
-      graphSettings.pointSize,
-      point1Color
-    );
-    graph.createCircle(
-      "points",
-      graphSettings.startingPoints[1],
-      graphSettings.pointSize,
-      point2Color
-    );
-
     graph.linearEquation.updateFunction();
 
     const moveAndUpdate = function (movedPoint: PointT, points: Array<PointT>) {

--- a/src/helpers/graph/graph-linear-util.js
+++ b/src/helpers/graph/graph-linear-util.js
@@ -38,7 +38,7 @@ const GraphLinearUtil = {
     };
 
     const onMouseDown = function (movedPoint: PointT, points: Array<PointT>) {
-      graph.linearEquation.startDraggingItemAt(movedPoint);
+      graph.linearEquation.startDraggingItemAt(movedPoint, false);
       moveAndUpdate(movedPoint, points);
     };
     const onMouseMove = function (movedPoint: PointT, points: Array<PointT>) {
@@ -48,9 +48,18 @@ const GraphLinearUtil = {
       moveAndUpdate(movedPoint, points);
       graph.linearEquation.stopDraggingItem();
     };
+    const onKeyDown = function(point: PointT, points: Array<PointT>) {
+      graph.linearEquation.startDraggingItemAt(point, true);
+      moveAndUpdate(point, points);
+    };
 
     if (graphSettings.canInteract)
-      graph.linearEquation.setDraggable(onMouseDown, onMouseMove, onMouseUp);
+      graph.linearEquation.setDraggable(
+        onMouseDown, 
+        onMouseMove, 
+        onMouseUp, 
+        onKeyDown
+      );
   },
 };
 export default GraphLinearUtil;

--- a/src/helpers/graph/graph-quadratic-util.js
+++ b/src/helpers/graph/graph-quadratic-util.js
@@ -42,7 +42,7 @@ const GraphQuadraticUtil = {
       point: PointT,
       points: QuadraticGraphPropertyT
     ) {
-      graph.quadraticEquation.startDraggingItemAt(point);
+      graph.quadraticEquation.startDraggingItemAt(point, false);
       moveAndUpdate(point, points);
     };
     const onMouseMove = function (
@@ -58,9 +58,13 @@ const GraphQuadraticUtil = {
       moveAndUpdate(point, points);
       graph.quadraticEquation.stopDraggingItem();
     };
+    const onKeyDown = function(point: PointT, points: QuadraticGraphPropertyT) {
+      graph.quadraticEquation.startDraggingItemAt(point, true);
+      moveAndUpdate(point, points);
+    };
 
     if (graphSettings.canInteract)
-      graph.quadraticEquation.setDraggable(onMouseDown, onMouseMove, onMouseUp);
+      graph.quadraticEquation.setDraggable(onMouseDown, onMouseMove, onMouseUp, onKeyDown);
   },
 };
 

--- a/src/helpers/graph/graph-quadratic-util.js
+++ b/src/helpers/graph/graph-quadratic-util.js
@@ -1,6 +1,4 @@
 /* @flow */
-
-import { getArrayOfNElements } from "./../array-helper.js";
 import { getClosestStepPoint } from "./../graph-util.js";
 
 import type {
@@ -19,23 +17,6 @@ const GraphQuadraticUtil = {
     ) => void,
     graphSettings: GraphSettingsT
   ) {
-    const [vertexColor, pointColor] = getArrayOfNElements(
-      graphSettings.pointColors,
-      2
-    );
-    graph.createCircle(
-      "vertex",
-      graphSettings.startingPoints[0],
-      graphSettings.pointSize,
-      vertexColor
-    );
-    graph.createCircle(
-      "point",
-      graphSettings.startingPoints[1],
-      graphSettings.pointSize,
-      pointColor
-    );
-
     graph.quadraticEquation.updateFunction();
 
     const moveAndUpdate = function (

--- a/src/helpers/graph/graph-scatter-points-util.js
+++ b/src/helpers/graph/graph-scatter-points-util.js
@@ -2,7 +2,6 @@
 
 import _ from "lodash";
 
-import { getArrayOfNElements } from "./../array-helper.js";
 import { getClosestStepPoint } from "./../graph-util.js";
 
 import type {
@@ -20,19 +19,6 @@ const GraphScatterPointsUtil = {
     ) => void,
     graphSettings: GraphSettingsT
   ) {
-    const pointColors = getArrayOfNElements(
-      graphSettings.pointColors,
-      graphSettings.startingPoints.length
-    );
-    _.forEach(graphSettings.startingPoints, (point, i) => {
-      graph.createCircle(
-        "points",
-        point,
-        graphSettings.pointSize,
-        graphSettings.pointColors[i]
-      );
-    });
-
     const moveAndUpdate = function (movedPoint: PointT, points: Array<PointT>) {
       const stepPoint = getClosestStepPoint(movedPoint, graphSettings);
       const stepPoints: Array<PointT> = _.map(points, (point) =>

--- a/src/helpers/graph/graph-scatter-points-util.js
+++ b/src/helpers/graph/graph-scatter-points-util.js
@@ -36,7 +36,7 @@ const GraphScatterPointsUtil = {
     };
 
     const onMouseDown = function (movedPoint: PointT, points: Array<PointT>) {
-      graph.scatterPoints.startDraggingItemAt(movedPoint);
+      graph.scatterPoints.startDraggingItemAt(movedPoint, false);
       moveAndUpdate(movedPoint, points);
     };
     const onMouseMove = function (movedPoint: PointT, points: Array<PointT>) {
@@ -46,9 +46,12 @@ const GraphScatterPointsUtil = {
       moveAndUpdate(movedPoint, points);
       graph.scatterPoints.stopDraggingItem();
     };
-
+    const onKeyDown = function(point: PointT, points: Array<PointT>) {
+      graph.scatterPoints.startDraggingItemAt(point, true);
+      moveAndUpdate(point, points);
+    };
     if (graphSettings.canInteract)
-      graph.scatterPoints.setDraggable(onMouseDown, onMouseMove, onMouseUp);
+      graph.scatterPoints.setDraggable(onMouseDown, onMouseMove, onMouseUp, onKeyDown);
   },
 };
 

--- a/src/helpers/paper-util.js
+++ b/src/helpers/paper-util.js
@@ -28,6 +28,8 @@ export type AnchorT
   | 'right'
   | 'top'
 
+export const ANNOUNCEMENT_NODE_ID = 'canvas-announcement'
+
 import
   { isPointBelowFunction
   , isPointCloseToFunction
@@ -184,6 +186,11 @@ const fromViewCoordinateToGrid = function(view: any, viewPoint: PaperPointT, gra
   )
 }
 
+function speakPoint(point: PointT): string {
+  const {x, y} = point
+  return `${Math.round(x)}, ${Math.round(y)}`
+}
+
 type GroupKeyT
   = 'grid'
   | 'points'
@@ -230,13 +237,16 @@ const PaperUtil = {
       this.pointsTool = new paper.Tool(pointsGroup)
       this.pointsTool.activate()
 
+      // used for aria-live announcements
+      this.announcementNode = document.getElementById(ANNOUNCEMENT_NODE_ID)
+
       // Provide keyboard accessible buttons for each
       // dragable coordinate point on the graph
       forEach(graphSettings.startingPoints, (p, index) => {
         const controlButton = document.createElement('button')
         const id = `control-button-${index}`
         controlButton.id = id
-        controlButton.innerText = `Coordinate ${index + 1}`
+        controlButton.innerText = `Coordinates ${speakPoint(p)}.`
         canvas.appendChild(controlButton)
         const paperCenterPoint = this.fromGridCoordinateToView(p)
         // round-robin colors
@@ -572,6 +582,7 @@ const PaperUtil = {
 
       moveDraggedItemAt: (point: PointT): boolean => {
         if (this.draggedItem) {
+          this.announcementNode.innerText = `Moved from coordinates (${speakPoint(this.fromViewCoordinateToGrid(this.draggedItem.position))}), to, coordinates ${speakPoint(point)}.`
           const paperPoint = this.fromGridCoordinateToView(point)
           this.draggedItem.position = paperPoint
           return true


### PR DESCRIPTION
https://app.asana.com/0/1201325186562318/1203201686089275/f
[SPIKE] Ss on SR/Keyboard can move coordinates on graph


It turns out that any elements nested inside the `<canvas>` are not visible to the user but are accessible to a screen-reader and focusable (if interactive) by the keyboard. This knowledge was key in making these graphs support keyboard interaction.
I created a one-to-one mapping between nested `button`s and points on the graph. Once a `button` is focused, the mapped point on the graph renders its focus state and listens for keyboard events.

![Peek 2023-01-23 22-10](https://user-images.githubusercontent.com/2381077/214097181-d16a844b-2f17-487a-bb0a-8cfa1c08a785.gif)

